### PR TITLE
fix: Resolve left top resizer error

### DIFF
--- a/components/canvas/selection-layer/rectangle-selection-box/left-top-resizer/left-top-resizer.tsx
+++ b/components/canvas/selection-layer/rectangle-selection-box/left-top-resizer/left-top-resizer.tsx
@@ -30,8 +30,8 @@ const LeftTopResizer: FC<{
       const newHeight = state.rectangle.height + state.rectangle.y - y;
 
       rectangle.moveTo(
-        x < state.rectangle.x + state.rectangle.width ? x : state.rectangle.x + state.rectangle.width - 1,
-        y,
+        newWidth > 0 ? x : state.rectangle.x + state.rectangle.width,
+        newHeight > 0 ? y : state.rectangle.y + state.rectangle.height,
       );
       rectangle.resize(newWidth > 0 ? newWidth : 1, newHeight > 0 ? newHeight : 1);
     };


### PR DESCRIPTION
Resizer shouldn't move y coordinate of rectangle when the new height is less than 1px